### PR TITLE
ASP2 support

### DIFF
--- a/components/alert/AlertBattleranks.vue
+++ b/components/alert/AlertBattleranks.vue
@@ -204,10 +204,9 @@ export default Vue.extend({
         })
     },
     buildCollection() {
-      const battleranks: number[] = [...Array(321).keys()]
-
       const battlerankData: { [k: number]: number } = []
       const factionBattlerankData: BattlerankDistributionDataInterface = {}
+      let maxBR: number = 0
 
       this.data.forEach((character) => {
         const battlerank = character.character.adjustedBattleRank
@@ -225,7 +224,18 @@ export default Vue.extend({
         battlerankData[battlerank]
           ? battlerankData[battlerank]++
           : (battlerankData[battlerank] = 1)
+
+        if(Number.isSafeInteger(battlerank)) {
+          maxBR = Math.max(maxBR, battlerank)
+        }
       })
+
+      let limit: number = 121
+      
+      while(limit < maxBR){
+        limit += 100
+      }
+      const battleranks: number[] = [...Array(limit).keys()]
 
       this.dataCollection = {
         labels: battleranks,

--- a/components/alert/AlertBattleranks.vue
+++ b/components/alert/AlertBattleranks.vue
@@ -191,7 +191,7 @@ export default Vue.extend({
         })
     },
     buildCollection() {
-      const battleranks: number[] = [...Array(221).keys()]
+      const battleranks: number[] = [...Array(321).keys()]
 
       const battlerankData: { [k: number]: number } = []
       const factionBattlerankData: BattlerankDistributionDataInterface = {}

--- a/components/alert/AlertBattleranks.vue
+++ b/components/alert/AlertBattleranks.vue
@@ -78,6 +78,19 @@ export default Vue.extend({
                 enabled: true,
               },
             },
+            {
+              drawTime: 'afterDatasetsDraw',
+              type: 'line',
+              mode: 'vertical',
+              scaleID: 'x-axis-0',
+              borderColor: 'rgba(255, 0, 0, 0.25)',
+              borderWidth: 2,
+              value: 221,
+              label: {
+                content: 'ASP2',
+                enabled: true,
+              },
+            },
           ],
         },
         scales: {

--- a/components/alert/AlertBattleranks.vue
+++ b/components/alert/AlertBattleranks.vue
@@ -225,14 +225,14 @@ export default Vue.extend({
           ? battlerankData[battlerank]++
           : (battlerankData[battlerank] = 1)
 
-        if(Number.isSafeInteger(battlerank)) {
+        if (Number.isSafeInteger(battlerank)) {
           maxBR = Math.max(maxBR, battlerank)
         }
       })
 
       let limit: number = 121
-      
-      while(limit < maxBR){
+
+      while (limit < maxBR) {
         limit += 100
       }
       const battleranks: number[] = [...Array(limit).keys()]

--- a/components/alert/AlertBattleranks.vue
+++ b/components/alert/AlertBattleranks.vue
@@ -197,9 +197,7 @@ export default Vue.extend({
       const factionBattlerankData: BattlerankDistributionDataInterface = {}
 
       this.data.forEach((character) => {
-        const battlerank = character.character.asp
-          ? character.character.battleRank + 120
-          : character.character.battleRank
+        const battlerank = character.character.adjustedBattleRank
 
         if (!factionBattlerankData[character.character.faction]) {
           factionBattlerankData[character.character.faction] = []

--- a/components/alert/AlertCharacterMetrics.vue
+++ b/components/alert/AlertCharacterMetrics.vue
@@ -296,9 +296,7 @@ export default Vue.extend({
         const tempData: AlertCharacterTableDataInterface = Object.assign(
           character,
           {
-            br: character.character.asp
-              ? character.character.battleRank + 120
-              : character.character.battleRank,
+            br: character.character.adjustedBattleRank,
             kd:
               character.kills && character.deaths
                 ? (character.kills / character.deaths).toFixed(2)

--- a/components/alert/AlertCharacterMetrics.vue
+++ b/components/alert/AlertCharacterMetrics.vue
@@ -26,7 +26,7 @@
         <p class="text-gray-400 text-sm mb-2 text-center">
           BR, ASP and Outfit Membership info is updated once every 24 hours
           (upon your next play session). Any players above BR 120 have ASPed
-          (220 max).
+          (320 max).
         </p>
         <div class="mb-2">
           <input

--- a/components/statistics/characters/Characters.vue
+++ b/components/statistics/characters/Characters.vue
@@ -185,9 +185,7 @@ export default Vue.extend({
               character.headshots && character.kills
                 ? ((character.headshots / character.kills) * 100).toFixed(2)
                 : 0,
-            br: character.character.asp
-              ? character.character.battleRank + 120
-              : character.character.battleRank,
+            br: character.character.adjustedBattleRank,
             worldName: worldNameFilter(character.world),
           }
         )

--- a/components/statistics/characters/CharactersLeaderboard.vue
+++ b/components/statistics/characters/CharactersLeaderboard.vue
@@ -15,7 +15,7 @@
           <p class="text-gray-400 text-sm mb-4 text-center">
             BR, ASP and Outfit Membership info is updated once every 24 hours
             (upon your next play session). Any players above BR 120 have ASPed
-            (220 max).
+            (320 max).
           </p>
           <div class="mb-2">
             <input

--- a/interfaces/CharacterInterface.ts
+++ b/interfaces/CharacterInterface.ts
@@ -8,6 +8,7 @@ export interface CharacterInterface {
   faction: Faction
   world: World
   battleRank: number
-  asp: boolean
+  asp: number
+  adjustedBattleRank: number
   outfit: OutfitInterface | null
 }


### PR DESCRIPTION
A few changes in this pull request:

1. The various places battlerank is displayed now rely on the aggregator and the API to calculate and return `adjustedBattleRank` rather than having multiple locations calculating the same value
2. Several text references to max BR of 220 have been updated to 320
3. The BR distribution graph is now clamped to the minimum value of (120, 220, 320, etc) needed to display all `adjustedBattleRank`s
4. Finally, the definition for an ASP2 annotation was added to the BR distribution graph. If those annotation renders were working properly, it would actually display on the graph, but that's a job for another pull request since it would go a bit beyond the scope of this one.

These changes rely on the `aggregator:asp2-support` and `api:asp2-support` branch changes, and the stack migration change is a nice to have so that global characters aren't missing battle ranks on their displays