### PR TITLE
Use new internal map API for all continents instead of just oshur

### DIFF
--- a/constants/Endpoints.ts
+++ b/constants/Endpoints.ts
@@ -63,6 +63,7 @@ export const Endpoints = {
 
   CENSUS_OSHUR_DATA: '/census/oshur',
   CENSUS_OSHUR_HEX_DATA: '/census/oshur-hex',
+  CENSUS_CONTINENT_HEX_DATA: '/census/regions/{zone}',
 
   INSTANCE_FACILITY_CONTROL_ENTRIES:
     '/instance-entries/{instance}/facility?sortBy=timestamp&order=desc',

--- a/libraries/MapRegionDataRequest.ts
+++ b/libraries/MapRegionDataRequest.ts
@@ -8,24 +8,10 @@ export default class MapRegionDataRequest {
   private data: MapRegion[] = []
 
   public async pull(zone: Zone): Promise<MapRegion[]> {
-    let request: Promise<CensusMapRegionResponseInterface>
-    switch (zone) {
-      case Zone.OSHUR:
-        request = new ApiRequest().get<CensusMapRegionResponseInterface>(
-          Endpoints.CENSUS_OSHUR_HEX_DATA
-        )
-        break
-      default:
-        request = new ApiRequest(
-          'https://census.daybreakgames.com'
-        ).get<CensusMapRegionResponseInterface>(
-          CensusEndpoints.CONTINENT_MAP_DATA.replace(
-            '{serviceId}',
-            'ps2alertsdotcom'
-          ).replace('{zone}', zone.toString())
-        )
-        break
-    }
+    const request = new ApiRequest().get<CensusMapRegionResponseInterface>(
+      Endpoints.CENSUS_CONTINENT_HEX_DATA.replace('{zone}', zone.valueOf().toString())
+    )
+    
     await request.then((result) => {
       const regionIdMap: Record<number, MapRegion> = {}
       result.map_region_list.forEach((region) => {

--- a/libraries/MapRegionDataRequest.ts
+++ b/libraries/MapRegionDataRequest.ts
@@ -1,6 +1,6 @@
 import { MapRegion } from './MapRegion'
 import ApiRequest from '~/api-request'
-import { CensusEndpoints, Endpoints } from '~/constants/Endpoints'
+import { Endpoints } from '~/constants/Endpoints'
 import { CensusMapRegionResponseInterface } from '~/interfaces/mapping/CensusMapRegionResponseInterface'
 import { Zone } from '~/constants/Zone'
 
@@ -9,9 +9,12 @@ export default class MapRegionDataRequest {
 
   public async pull(zone: Zone): Promise<MapRegion[]> {
     const request = new ApiRequest().get<CensusMapRegionResponseInterface>(
-      Endpoints.CENSUS_CONTINENT_HEX_DATA.replace('{zone}', zone.valueOf().toString())
+      Endpoints.CENSUS_CONTINENT_HEX_DATA.replace(
+        '{zone}',
+        zone.valueOf().toString()
+      )
     )
-    
+
     await request.then((result) => {
       const regionIdMap: Record<number, MapRegion> = {}
       result.map_region_list.forEach((region) => {


### PR DESCRIPTION
Since the recent 19th anniversary update included some stealth changes to lattices that are not reflected in census, our maps were out of date with in game maps. This change uses an internal API to retrieve map data to bring the maps back in sync with in game maps.

Closes #413 