### PR TITLE
Support map changes to Oshur

### DIFF
--- a/components/alert/AlertMap.vue
+++ b/components/alert/AlertMap.vue
@@ -296,10 +296,10 @@ export default Vue.extend({
       prevZoom: 2,
       center: [-128, 128],
       url:
-        AssetsBaseUrl +
-        '/zones/' +
-        zoneNameFilter(this.alert.zone).toLowerCase() +
-        '/{z}/tile_{x}_{y}.png',
+        AssetsBaseUrl + '/zones/' + this.alert.mapVersion ??
+        '/1.0/' +
+          zoneNameFilter(this.alert.zone).toLowerCase() +
+          '/{z}/tile_{x}_{y}.png',
       minZoom: 2,
       maxZoom: 7,
       zoomSnap: 0.5,

--- a/constants/FacilityType.ts
+++ b/constants/FacilityType.ts
@@ -11,6 +11,7 @@ export enum FacilityType {
   RELIC_OUTPOST = 10, // Desolation only
   CONTAINMENT_SITE = 11,
   TRIDENT = 12,
+  UNDERWATER = 13,
 }
 
 export const MAJOR_FACILITIES = [

--- a/filters/FacilityTypeShortName.ts
+++ b/filters/FacilityTypeShortName.ts
@@ -27,6 +27,8 @@ const facilityTypeShortName = Vue.filter(
         return 'con-site'
       case FacilityType.TRIDENT:
         return 'trid'
+      case FacilityType.UNDERWATER:
+        return 'seapost'
       default:
         return 'unknown'
     }

--- a/interfaces/InstanceTerritoryControlResponseInterface.ts
+++ b/interfaces/InstanceTerritoryControlResponseInterface.ts
@@ -18,4 +18,5 @@ export interface InstanceTerritoryControlResponseInterface {
   result: TerritoryResultInterface
   bracket: Bracket
   features?: PS2AlertsInstanceFeaturesInterface
+  mapVersion?: string
 }

--- a/libraries/FacilityBadge.ts
+++ b/libraries/FacilityBadge.ts
@@ -104,7 +104,7 @@ export class FacilityBadge {
   constructor(region: MapRegion, indictorStamp: number, textStamp: number) {
     this.indicatorStamp = indictorStamp
     this.textStamp = textStamp
-    if(region.name.includes("Seapost") || region.name == "Bathala Garden"){
+    if (region.name.includes('Seapost') || region.name === 'Bathala Garden') {
       this.type = FacilityType.UNDERWATER
     } else {
       this.type = region.facilityType

--- a/libraries/FacilityBadge.ts
+++ b/libraries/FacilityBadge.ts
@@ -104,7 +104,11 @@ export class FacilityBadge {
   constructor(region: MapRegion, indictorStamp: number, textStamp: number) {
     this.indicatorStamp = indictorStamp
     this.textStamp = textStamp
-    this.type = region.facilityType
+    if(region.name.includes("Seapost") || region.name == "Bathala Garden"){
+      this.type = FacilityType.UNDERWATER
+    } else {
+      this.type = region.facilityType
+    }
     this.svg = SVG()
     this.svg.viewbox(0, 0, 100, 100)
     this.text = SVG()
@@ -381,6 +385,8 @@ export class FacilityBadge {
         return 'containment-fg'
       case FacilityType.TRIDENT:
         return 'trident-fg'
+      case FacilityType.UNDERWATER:
+        return 'seapost-fg'
       default:
         return ''
     }

--- a/static/img/facility-icon.svg
+++ b/static/img/facility-icon.svg
@@ -70,6 +70,14 @@
             <polygon stroke="none" fill="white" points="66.8,40.8 59.67,43.1 57.5,36"/>
             <polygon stroke="none" fill="white" points="50,55 60,65 50,75 40,65"/>
         </g>
+        <g id="seapost-fg" stroke="white" stroke-width="5" fill="none">
+            <circle cx="50" cy="25" r="10"/>
+            <line x1="50" y1="35" x2="50" y2="80"/>
+            <line x1="42.5" y1="45" x2="57.5" y2="45"/>
+            <path fill="white" stroke="none" d="M 14.644 65.355 A 42.5 42.5 0 0 0 85.355 65.355 A 57.5 57.5 0 0 1 14.644 65.355"/>
+            <path fill="white" stroke="none" d="M 14.644 65.355 L 30 68 L 22.5 72.5 Z"/>
+            <path fill="white" stroke="none" d="M 85.355 65.355 L 70 68 L 77.5 72.5 Z"/>
+        </g>
     </defs>
     <!--<rect x="0" y="0" width="100" height="100" fill="black"/>
     <use href="#facility-bg" fill="red"/>


### PR DESCRIPTION
New bases were added and the hexes were shuffled around for existing bases with the Sea and Storm update. This adds support for the new base type with anchor indicators (through a *wonderful* special case /s since the facility type ids weren't changed)