### PR TITLE
fixed mobile small buttons

### DIFF
--- a/assets/css/tailwind.scss
+++ b/assets/css/tailwind.scss
@@ -359,6 +359,9 @@
   .btn-sm {
     @apply text-sm py-1 px-2 rounded-sm;
   }
+  .btn-smmobile {
+    @apply btn-sm p-1
+  }
   .btn-xs {
     @apply text-xs p-1 rounded-sm;
   }

--- a/assets/css/tailwind.scss
+++ b/assets/css/tailwind.scss
@@ -357,7 +357,7 @@
     }
   }
   .btn-sm {
-    @apply text-sm py-1 px-1 rounded-sm;
+    @apply text-sm py-1 px-2 rounded-sm;
   }
   .btn-xs {
     @apply text-xs p-1 rounded-sm;

--- a/assets/css/tailwind.scss
+++ b/assets/css/tailwind.scss
@@ -357,10 +357,7 @@
     }
   }
   .btn-sm {
-    @apply text-sm py-1 px-2 rounded-sm;
-  }
-  .btn-smmobile {
-    @apply btn-sm p-1
+    @apply text-sm py-1 px-1 rounded-sm;
   }
   .btn-xs {
     @apply text-xs p-1 rounded-sm;

--- a/components/alert/AlertCombatHistory.vue
+++ b/components/alert/AlertCombatHistory.vue
@@ -10,44 +10,44 @@
       <h1 class="mb-4">Loading...</h1>
     </div>
     <div v-if="loaded" class="text-center">
-      <div class="btn-group mr-2">
+      <div class="btn-group justify-center flex">
         <button
-          class="btn btn-sm"
+          class="btn btn-smmobile md:btn-sm"
           :class="{ 'btn-active': mode === 'kills' }"
           @click="updateMode('kills')"
         >
           Kills
         </button>
         <button
-          class="btn btn-sm"
+          class="btn btn-smmobile md:btn-sm"
           :class="{ 'btn-active': mode === 'deaths' }"
           @click="updateMode('deaths')"
         >
           Deaths
         </button>
         <button
-          class="btn btn-sm"
+          class="btn btn-smmobile md:btn-sm"
           :class="{ 'btn-active': mode === 'kd' }"
           @click="updateMode('kd')"
         >
           KD
         </button>
         <button
-          class="btn btn-sm"
+          class="btn btn-smmobile md:btn-sm"
           :class="{ 'btn-active': mode === 'teamKills' }"
           @click="updateMode('teamKills')"
         >
           Teamkills
         </button>
         <button
-          class="btn btn-sm"
+          class="btn btn-smmobile md:btn-sm"
           :class="{ 'btn-active': mode === 'suicides' }"
           @click="updateMode('suicides')"
         >
           Suicides
         </button>
         <button
-          class="btn btn-sm"
+          class="btn btn-smmobile md:btn-sm"
           :class="{ 'btn-active': mode === 'headshots' }"
           @click="updateMode('headshots')"
         >

--- a/components/alert/AlertCombatHistory.vue
+++ b/components/alert/AlertCombatHistory.vue
@@ -10,44 +10,44 @@
       <h1 class="mb-4">Loading...</h1>
     </div>
     <div v-if="loaded" class="text-center">
-      <div class="btn-group justify-center flex">
+      <div class="md:btn-group justify-center grid grid-cols-3 md:flex">
         <button
-          class="btn btn-sm"
+          class="btn btn-sm mx-1 my-1 md:mx-0 md:my-0 col-span-1"
           :class="{ 'btn-active': mode === 'kills' }"
           @click="updateMode('kills')"
         >
           Kills
         </button>
         <button
-          class="btn btn-smmobile md:btn-sm"
+          class="btn btn-sm mx-1 my-1 md:mx-0 md:my-0 col-span-1"
           :class="{ 'btn-active': mode === 'deaths' }"
           @click="updateMode('deaths')"
         >
           Deaths
         </button>
         <button
-          class="btn btn-smmobile md:btn-sm"
+          class="btn btn-sm mx-1 my-1 md:mx-0 md:my-0 col-span-1"
           :class="{ 'btn-active': mode === 'kd' }"
           @click="updateMode('kd')"
         >
           KD
         </button>
         <button
-          class="btn btn-smmobile md:btn-sm"
+          class="btn btn-sm mx-1 my-1 md:mx-0 md:my-0 col-span-1"
           :class="{ 'btn-active': mode === 'teamKills' }"
           @click="updateMode('teamKills')"
         >
           Teamkills
         </button>
         <button
-          class="btn btn-sm"
+          class="btn btn-sm mx-1 my-1 md:mx-0 md:my-0 col-span-1"
           :class="{ 'btn-active': mode === 'suicides' }"
           @click="updateMode('suicides')"
         >
           Suicides
         </button>
         <button
-          class="btn btn-smmobile md:btn-sm"
+          class="btn btn-sm mx-1 my-1 md:mx-0 md:my-0 col-span-1"
           :class="{ 'btn-active': mode === 'headshots' }"
           @click="updateMode('headshots')"
         >

--- a/components/alert/AlertCombatHistory.vue
+++ b/components/alert/AlertCombatHistory.vue
@@ -12,7 +12,7 @@
     <div v-if="loaded" class="text-center">
       <div class="btn-group justify-center flex">
         <button
-          class="btn btn-smmobile md:btn-sm"
+          class="btn btn-sm"
           :class="{ 'btn-active': mode === 'kills' }"
           @click="updateMode('kills')"
         >
@@ -40,7 +40,7 @@
           Teamkills
         </button>
         <button
-          class="btn btn-smmobile md:btn-sm"
+          class="btn btn-sm"
           :class="{ 'btn-active': mode === 'suicides' }"
           @click="updateMode('suicides')"
         >


### PR DESCRIPTION
I've made some changes to address buttons being cut off on mobile now they look like this
Just to note on the new .btn-smmobile that I've made p-1 override the padding in the btn-sm that I've applied
![image](https://user-images.githubusercontent.com/61867169/181517549-68001f23-b26b-49bc-abe9-c7bbe95d85c0.png)

And on desktop they retain their standard look like this:

![image](https://user-images.githubusercontent.com/61867169/181517657-fb1d5066-a411-414c-b3cd-f636b77c732d.png)
