### PR TITLE
467 player and outfit counts look wonky on mobile

### DIFF
--- a/components/alert/AlertCharacterMetrics.vue
+++ b/components/alert/AlertCharacterMetrics.vue
@@ -10,7 +10,7 @@
       <h1>Loading...</h1>
     </div>
     <div v-if="loaded" class="grid grid-cols-12">
-      <div class="col-start-1 col-span-full mb-2 flex flex-wrap justify-center">
+      <div class="col-span-full mb-2 flex flex-wrap justify-center">
         <div class = "p-2">Player Counts</div>
         <div
           v-for="(count, index) in counts"

--- a/components/alert/AlertCharacterMetrics.vue
+++ b/components/alert/AlertCharacterMetrics.vue
@@ -11,7 +11,7 @@
     </div>
     <div v-if="loaded" class="grid grid-cols-12">
       <div class="col-span-full mb-2 flex flex-wrap justify-center">
-        <div class = "p-2">Player Counts</div>
+        <div class="p-2">Player Counts</div>
         <div
           v-for="(count, index) in counts"
           :key="index"

--- a/components/alert/AlertCharacterMetrics.vue
+++ b/components/alert/AlertCharacterMetrics.vue
@@ -10,8 +10,8 @@
       <h1>Loading...</h1>
     </div>
     <div v-if="loaded" class="grid grid-cols-12">
-      <div class="col-span-12 mb-2 flex justify-center">
-        <div class="pr-2 py-2">Player Counts:</div>
+    <div class="col-start-5 col-span-4 flex align-center justify-center mb-2">Player Counts</div>
+      <div class="col-start-4 col-span-full  md:col-start-4 md:col-span-5 mb-2 flex justify-center md:mr-1">
         <div
           v-for="(count, index) in counts"
           :key="index"

--- a/components/alert/AlertCharacterMetrics.vue
+++ b/components/alert/AlertCharacterMetrics.vue
@@ -10,8 +10,9 @@
       <h1>Loading...</h1>
     </div>
     <div v-if="loaded" class="grid grid-cols-12">
-    <div class="col-start-5 col-span-4 flex align-center justify-center mb-2">Player Counts</div>
-      <div class="col-start-4 col-span-full  md:col-start-4 md:col-span-5 mb-2 flex justify-center md:mr-1">
+    
+      <div class="col-start-1 col-span-full mb-2 flex flex-wrap justify-center ">
+        <div class = "p-2">Player Counts</div>
         <div
           v-for="(count, index) in counts"
           :key="index"

--- a/components/alert/AlertCharacterMetrics.vue
+++ b/components/alert/AlertCharacterMetrics.vue
@@ -10,8 +10,7 @@
       <h1>Loading...</h1>
     </div>
     <div v-if="loaded" class="grid grid-cols-12">
-    
-      <div class="col-start-1 col-span-full mb-2 flex flex-wrap justify-center ">
+      <div class="col-start-1 col-span-full mb-2 flex flex-wrap justify-center">
         <div class = "p-2">Player Counts</div>
         <div
           v-for="(count, index) in counts"


### PR DESCRIPTION
Updated on styling need review on how to change it further

Or maybe a simpler version may be 
![image](https://user-images.githubusercontent.com/61867169/182245632-f25e50e5-622a-462d-ba00-d2ea1438d5db.png)
This is on Iphone SE which has a very small x-axis
![image](https://user-images.githubusercontent.com/61867169/182245705-a8d2c8ac-edab-4611-9151-c61ec11a53fb.png)
Looks much nicer on a larger phone where the whole line is visible
And on ipad
![image](https://user-images.githubusercontent.com/61867169/182245792-76447c4e-e222-440e-ac5f-6f37f69b57b9.png)
And then on PC it looks fine
![image](https://user-images.githubusercontent.com/61867169/182245875-ba05272f-91a0-4ac5-9b38-bfba31a537ec.png)
Also this reduces the code complexity a bit since no breakpoints are needed as these are the same styles that are themselves adapting to the size of the display