### PR TITLE
Fixed the reverse check for debugging on the population history 

### DIFF
--- a/components/alert/AlertPopulations.vue
+++ b/components/alert/AlertPopulations.vue
@@ -56,7 +56,7 @@
 
       <div v-show="mode === 'number'">
         <line-chart
-          v-if="!dataCollection"
+          v-if="dataCollection"
           :chart-data="dataCollection"
           :options="popNumberChartOptions"
           style="height: 400px"


### PR DESCRIPTION
It was there for debugging purposes but I forgot to remove it