### PR TITLE
Use new current-round API on the rankings page to dedupe logic

### DIFF
--- a/components/outfitwars/RoundBracketEntry.vue
+++ b/components/outfitwars/RoundBracketEntry.vue
@@ -245,7 +245,7 @@ export default Vue.extend({
     },
     getLabelClass(faction: Faction): object {
       const factionSmall = factionShortName(faction)
-      console.log(factionSmall)
+      // console.log(factionSmall)
       return {
         label: true,
         [factionSmall]: true,

--- a/components/statistics/victories/Victories.vue
+++ b/components/statistics/victories/Victories.vue
@@ -160,9 +160,13 @@ export default Vue.extend({
       // Request each bracket's data then merge into a singular array
       await Promise.all(promises)
         .then((results) => {
+          let newData: GlobalVictoriesAggregateResponseInterface[] = []
+
           results.forEach((bracketResult) => {
-            this.data = this.data.concat(bracketResult)
+            newData = newData.concat(bracketResult)
           })
+
+          this.data = newData
           this.loaded = true
           this.loading = false
 

--- a/pages/outfit-wars/index.vue
+++ b/pages/outfit-wars/index.vue
@@ -466,21 +466,27 @@ export default Vue.extend({
       }
 
       console.log('OutfitwarsRankings.pull')
-      const currentRoundRequests = [];
-      for(const world of this.worlds) {
-        currentRoundRequests.push(new ApiRequest()
-          .get<number>(ps2AlertsApiEndpoints.outfitwarsCurrentRoundByWorld.replace('{world}', world.toString())))
+      const currentRoundRequests = []
+      for (const world of this.worlds) {
+        currentRoundRequests.push(
+          new ApiRequest().get<number>(
+            ps2AlertsApiEndpoints.outfitwarsCurrentRoundByWorld.replace(
+              '{world}',
+              world.toString()
+            )
+          )
+        )
       }
 
       await Promise.all(currentRoundRequests).then((result) => {
-        this.worldRounds = result;
+        this.worldRounds = result
       })
 
-      console.log(this.worldRounds);
+      console.log(this.worldRounds)
 
       await new ApiRequest()
         .get<OutfitwarsRankingInterface[]>(Endpoints.OW_RANKINGS_ALL)
-        .then(async (result) => {
+        .then((result) => {
           console.log('result', result)
           this.parse(result)
         })
@@ -607,6 +613,7 @@ export default Vue.extend({
       if (currentOrUpdatingRound) {
         const outfits = new Map<string, ParsedOutfitDataInterface>()
         const ids: string[] = []
+
         for (const ranking of worldRankings) {
           const outfitExists = outfits.has(ranking.id)
 
@@ -626,6 +633,7 @@ export default Vue.extend({
 
         for (const id of ids) {
           const record = outfits.get(id)
+
           if (record === undefined) {
             // eslint.......
             console.error('Somehow this data we set just now is now undefined?')
@@ -636,6 +644,7 @@ export default Vue.extend({
       } else {
         toReturn = worldRankings
       }
+
       return toReturn
     },
 
@@ -660,6 +669,7 @@ export default Vue.extend({
           tr: 0,
         })
         const worldStatMap = statMap.get(world)
+
         for (const outfit of this.worldRankings(world, true)) {
           const faction: string = factionShortName(outfit.faction).toLowerCase()
 

--- a/pages/outfit-wars/index.vue
+++ b/pages/outfit-wars/index.vue
@@ -318,7 +318,7 @@
         </v-tab>
       </v-tabs>
 
-      <v-tabs-items v-model="activeBracketTab">
+      <v-tabs-items v-model="activeBracketTab" touchless>
         <v-tab-item
           v-for="world in worlds"
           :key="world + '-tab'"


### PR DESCRIPTION
Also removed some pretty verbose logging the round bracket entries were doing