### PR TITLE
Add a match start grace period and fix playoff 2/championship seeding

### DIFF
--- a/components/outfitwars/RoundBracket.vue
+++ b/components/outfitwars/RoundBracket.vue
@@ -211,33 +211,28 @@ export default Vue.extend({
           }
           break
         case 7: {
-          const matchOneWinner = filteredRankings.find((ranking) => {
-            return ranking.id === previousWinners[0].id
-          })
-          const matchOneLoser = filteredRankings.find((ranking) => {
-            return ranking.id === previousLosers[0].id
-          })
-          const matchTwoWinner = filteredRankings.find((ranking) => {
-            return ranking.id === previousWinners[1].id
-          })
-          const matchTwoLoser = filteredRankings.find((ranking) => {
-            return ranking.id === previousLosers[1].id
-          })
-          if (
-            matchOneWinner === undefined ||
-            matchTwoWinner === undefined ||
-            matchOneLoser === undefined ||
-            matchTwoLoser === undefined
-          ) {
-            console.error('Playoff 2 winners not found in current rankings?')
-            break
+          const winners: ParsedOutfitDataInterface[] = []
+          const losers: ParsedOutfitDataInterface[] = []
+          for (let i = 0; i < 2; i += 1) {
+            const winner = filteredRankings.find((ranking) => {
+              return ranking.id === previousWinners[i].id
+            })
+            const loser = filteredRankings.find((ranking) => {
+              return ranking.id === previousLosers[i].id
+            })
+            if (!winner || !loser) {
+              console.error(
+                'Playoff 2 winners/losers not found in current rankings?'
+              )
+              break
+            }
+            winner.index = previousWinners[i].index
+            loser.index = previousLosers[i].index
+            winners.push(winner)
+            losers.push(loser)
           }
-          matchOneWinner.index = previousWinners[0].index
-          matchTwoWinner.index = previousWinners[1].index
-          matchOneLoser.index = previousLosers[0].index
-          matchTwoLoser.index = previousLosers[1].index
-          this.pairs.push([matchOneWinner, matchTwoWinner])
-          this.pairs.push([matchOneLoser, matchTwoLoser])
+          this.pairs.push(winners)
+          this.pairs.push(losers)
           break
         }
         default:

--- a/components/outfitwars/RoundBracket.vue
+++ b/components/outfitwars/RoundBracket.vue
@@ -195,16 +195,15 @@ export default Vue.extend({
           break
         case 6:
           for (let i = 0; i < 2; i += 1) {
-            let first = filteredRankings.find((ranking) => {
+            const first = filteredRankings.find((ranking) => {
               return ranking.id === previousWinners[i].id
             })
-            let second = filteredRankings.find((ranking) => {
+            const second = filteredRankings.find((ranking) => {
               return ranking.id === previousWinners[3 - i].id
             })
             if (first === undefined || second === undefined) {
-              console.error('Winners not found in current rankings?')
-              first = previousWinners[i]
-              second = previousWinners[3 - i]
+              console.error('Playoff 1 winners not found in current rankings?')
+              break
             }
             first.index = previousWinners[i].index
             second.index = previousWinners[3 - i].index
@@ -230,6 +229,7 @@ export default Vue.extend({
             matchOneLoser === undefined ||
             matchTwoLoser === undefined
           ) {
+            console.error('Playoff 2 winners not found in current rankings?')
             break
           }
           matchOneWinner.index = previousWinners[0].index

--- a/components/outfitwars/RoundBracket.vue
+++ b/components/outfitwars/RoundBracket.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="w-full xl:w-2/3 3xl:max-w-4xl m-auto px-2">
-    <div v-if="rankingPairs.length > 0" class="mb-2">
+  <div v-if="loaded" class="w-full xl:w-2/3 3xl:max-w-4xl m-auto px-2">
+    <div v-if="rankingPairs().length > 0" class="mb-2">
       <div class="text-xl">
         {{ phase | phaseName }}
       </div>
@@ -9,15 +9,13 @@
       </div>
       <div v-else class="text-sm">Final</div>
     </div>
-    <div v-if="loaded">
-      <RoundBracketEntry
-        v-for="(rankingPair, index) in rankingPairs()"
-        v-if="rankingPair[0].world !== 40"
-        :key="index"
-        :rankings="rankingPair"
-        :current-round="currentRound"
-      />
-    </div>
+    <RoundBracketEntry
+      v-for="(rankingPair, index) in rankingPairs()"
+      v-if="rankingPair[0].world !== 40"
+      :key="index"
+      :rankings="rankingPair"
+      :current-round="currentRound"
+    />
   </div>
 </template>
 

--- a/components/outfitwars/RoundBracket.vue
+++ b/components/outfitwars/RoundBracket.vue
@@ -126,6 +126,7 @@ export default Vue.extend({
       let playoffSeedingRankings: ParsedOutfitDataInterface[] = []
       const previousPairs: ParsedOutfitDataInterface[][] = []
       let previousWinners: ParsedOutfitDataInterface[] = []
+      let previousLosers: ParsedOutfitDataInterface[] = []
 
       if (this.round > 5) {
         winners = this.previousRoundMatches.map((match) => {
@@ -175,6 +176,13 @@ export default Vue.extend({
             return pair[1]
           }
         })
+        previousLosers = previousPairs.map((pair) => {
+          if (!winners.includes(pair[0].id)) {
+            return pair[0]
+          } else {
+            return pair[1]
+          }
+        })
       }
 
       switch (this.round) {
@@ -186,7 +194,6 @@ export default Vue.extend({
           }
           break
         case 6:
-        case 7:
           for (let i = 0; i < 2; i += 1) {
             let first = filteredRankings.find((ranking) => {
               return ranking.id === previousWinners[i].id
@@ -204,6 +211,35 @@ export default Vue.extend({
             this.pairs.push([first, second])
           }
           break
+        case 7: {
+          const matchOneWinner = filteredRankings.find((ranking) => {
+            return ranking.id === previousWinners[0].id
+          })
+          const matchOneLoser = filteredRankings.find((ranking) => {
+            return ranking.id === previousLosers[0].id
+          })
+          const matchTwoWinner = filteredRankings.find((ranking) => {
+            return ranking.id === previousWinners[1].id
+          })
+          const matchTwoLoser = filteredRankings.find((ranking) => {
+            return ranking.id === previousLosers[1].id
+          })
+          if (
+            matchOneWinner === undefined ||
+            matchTwoWinner === undefined ||
+            matchOneLoser === undefined ||
+            matchTwoLoser === undefined
+          ) {
+            break
+          }
+          matchOneWinner.index = previousWinners[0].index
+          matchTwoWinner.index = previousWinners[1].index
+          matchOneLoser.index = previousLosers[0].index
+          matchTwoLoser.index = previousLosers[1].index
+          this.pairs.push([matchOneWinner, matchTwoWinner])
+          this.pairs.push([matchOneLoser, matchTwoLoser])
+          break
+        }
         default:
           for (let i = 0; i + 1 < sortedRankings.length; i += 2) {
             if (this.round > 5 && i === 4) {

--- a/components/outfitwars/RoundBracketEntry.vue
+++ b/components/outfitwars/RoundBracketEntry.vue
@@ -370,10 +370,11 @@ export default Vue.extend({
       return FactionTextClass(faction)
     },
     getUserTime(datetime: Date): string {
-      // If match time is in the past which is a common occurrence for the future matches until we get official data, display TBA
+      // If match time is in the past which is a common occurrence for the future matches until we get official data, display TBA - unless we are in the 20 minute prep phase
       const now = new Date();
+      const twentyMinMS = 1200000;
 
-      if (datetime.getTime() < now.getTime() && this.rankings[0].round === this.currentRound) {
+      if ((datetime.getTime() + twentyMinMS) < now.getTime() && this.rankings[0].round === this.currentRound) {
         return 'Not yet scheduled'
       }
 

--- a/pages/outfit-wars/index.vue
+++ b/pages/outfit-wars/index.vue
@@ -246,8 +246,9 @@
               v-for="(outfit, index) in worldRankings(world, true)"
               :key="outfit.id"
               class="border-b border-b-gray-600 grid grid-cols-12"
-              :class="index === 7 || index === worldRankings(world, true).length - 1 ? {'border-b-0': true} : {}"
+              :class="index === 3 || index === 7 || index === worldRankings(world, true).length - 1 ? {'border-b-0': true} : {}"
             >
+              <div class="col-span-12 border border-y-red-500 border-y-2 border-x-0 py-2 text-xs" v-if="index === 4">Championship cutoff</div>
               <div class="col-span-12 border border-y-red-500 border-y-2 border-x-0 py-2 text-xs" v-if="index === 8">Qualifier cutoff</div>
               <div class="col-span-12 grid grid-cols-12 gap-x-2 p-2 content-center h-24">
                 <div class="col-span-1 text-center flex">
@@ -327,14 +328,12 @@
           :value="getTabValue(world)"
         >
           <section>
-            <div
-              class="bg-tint rounded border border-gray-900"
-            >
+            <div class="bg-tint rounded border border-gray-900">
               <div
                 v-for="(round, index) in rounds"
                 :key="index"
                 class="my-2 py-2 border-b border-b-gray-500"
-                :class="round === 1 ? {'border-b-0': true, 'pb-1': true} : {}"
+                :class="round === 1 ? { 'border-b-0': true, 'pb-1': true } : {}"
               >
                 <RoundBracket
                   :rankings="worldRankings(world)"


### PR DESCRIPTION
This pull request fixes two issues - playoff 2 seeding was not correctly ordered by winner of the previous match and when matches were starting up the time would not be shown.

Theoretically this seeding scheme should work for both playoff 2 and the championship rounds, so I've made it generic enough to work for both, though it really isn't the prettiest of code. This should also carry the seeds from the first playoff round throughout the bracket, so each team will have their seed shown in all of the playoff and championship rounds