### PR TITLE
Fix overcomplication of logic for playoff round 2

### DIFF
--- a/components/outfitwars/RoundBracket.vue
+++ b/components/outfitwars/RoundBracket.vue
@@ -193,18 +193,14 @@ export default Vue.extend({
           break
         case 6:
           for (let i = 0; i < 2; i += 1) {
-            const first = filteredRankings.find((ranking) => {
-              return ranking.id === previousWinners[i].id
-            })
-            const second = filteredRankings.find((ranking) => {
-              return ranking.id === previousWinners[3 - i].id
-            })
-            if (first === undefined || second === undefined) {
-              console.error('Playoff 1 winners not found in current rankings?')
-              break
-            }
-            first.index = previousWinners[i].index
-            second.index = previousWinners[3 - i].index
+            const first = filteredRankings[i]
+            const second = filteredRankings[3 - i]
+            first.index = previousWinners.find(
+              (ranking) => ranking.id === first.id
+            )?.index
+            second.index = previousWinners.find(
+              (ranking) => ranking.id === second.id
+            )?.index
             this.pairs.push([first, second])
           }
           break


### PR DESCRIPTION
I'd overcomplicated the logic assuming a bracketing system was in place, but apparently the system in game is based on points still. This caused an issue on miller due to an upset which left the 7th seed team still at the bottom of the list in terms of points - under the system I created they were matched with the winner of the 4v5 match rather than being matched with the first place team.