### PR TITLE
Add Lattice Versioning separate from Map Tile versioning

### DIFF
--- a/components/alert/AlertMap.vue
+++ b/components/alert/AlertMap.vue
@@ -1248,7 +1248,7 @@ export default Vue.extend({
       }
       const regions = await new MapRegionDataRequest().pull(
         zone,
-        this.alert.mapVersion ?? '1.0'
+        this.alert.latticeVersion ?? '1.0'
       )
 
       regions.forEach((region) => {

--- a/filters/FacilityTypeName.ts
+++ b/filters/FacilityTypeName.ts
@@ -10,6 +10,7 @@ const facilityTypeName = Vue.filter(
       case FacilityType.DEFAULT:
         return 'Default / Unknown'
       case FacilityType.AMP_STATION:
+      case FacilityType.CTF_AMP_STATION:
         return 'Amp Station'
       case FacilityType.BIO_LAB:
         return 'Biolab'

--- a/filters/FacilityTypeShortName.ts
+++ b/filters/FacilityTypeShortName.ts
@@ -29,6 +29,14 @@ const facilityTypeShortName = Vue.filter(
         return 'trid'
       case FacilityType.UNDERWATER:
         return 'seapost'
+      case FacilityType.CTF_AMP_STATION:
+        return 'ctf-amp'
+      case FacilityType.CTF_CONSTRUCTION_OUTPOST:
+        return 'ctf-const'
+      case FacilityType.CTF_LARGE_OUTPOST:
+        return 'ctf-lg-out'
+      case FacilityType.CTF_SMALL_OUTPOST:
+        return 'ctf-sm-out'
       default:
         return 'unknown'
     }

--- a/interfaces/InstanceOutfitWarsResponseInterface.ts
+++ b/interfaces/InstanceOutfitWarsResponseInterface.ts
@@ -17,6 +17,7 @@ export interface InstanceOutfitWarsResponseInterface {
   state: Ps2AlertsEventState
   outfitwars: OutfitWarsMetadataInterface
   mapVersion?: string
+  latticeVersion?: string
   result: OutfitwarsTerritoryResultInterface
   features?: PS2AlertsInstanceFeaturesInterface
   ps2AlertsEventType?: Ps2AlertsEventType

--- a/interfaces/InstanceTerritoryControlResponseInterface.ts
+++ b/interfaces/InstanceTerritoryControlResponseInterface.ts
@@ -20,5 +20,6 @@ export interface InstanceTerritoryControlResponseInterface {
   bracket: Bracket
   features?: PS2AlertsInstanceFeaturesInterface
   mapVersion?: string
+  latticeVersion?: string
   ps2AlertsEventType?: Ps2AlertsEventType
 }

--- a/interfaces/mapping/CensusMapRegionInterface.ts
+++ b/interfaces/mapping/CensusMapRegionInterface.ts
@@ -9,5 +9,5 @@ export interface CensusMapRegionInterface {
   location_x: string | undefined
   location_z: string | undefined
   facility_links: Array<CensusFacilityLinkInterface> | undefined
-  map_hexes: Array<CensusMapHexInterface>
+  map_hexes: Array<CensusMapHexInterface> | undefined
 }

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -39,6 +39,6 @@
         </client-only>
       </div>
     </div>
+    <component is="script" type="application/javascript" defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "19d104869b6c4c87aa963b807cfe5461"}'></component>
   </main>
-  <script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "19d104869b6c4c87aa963b807cfe5461"}'></script>
 </template>

--- a/libraries/FacilityBadge.ts
+++ b/libraries/FacilityBadge.ts
@@ -144,6 +144,7 @@ export class FacilityBadge {
     const matchesLength = value.match(/ /g)?.length
     switch (this.region.facilityType) {
       case FacilityType.AMP_STATION:
+      case FacilityType.CTF_AMP_STATION:
       case FacilityType.BIO_LAB:
       case FacilityType.TECH_PLANT:
         value = value + '\n' + facilityTypeName(this.region.facilityType)

--- a/libraries/FacilityBadge.ts
+++ b/libraries/FacilityBadge.ts
@@ -329,8 +329,12 @@ export class FacilityBadge {
       case FacilityType.SMALL_OUTPOST:
       case FacilityType.CONSTRUCTION_OUTPOST:
       case FacilityType.RELIC_OUTPOST:
+      case FacilityType.CTF_SMALL_OUTPOST:
+      case FacilityType.CTF_CONSTRUCTION_OUTPOST:
+      case FacilityType.UNDERWATER:
         return zoom >= 4
       case FacilityType.LARGE_OUTPOST:
+      case FacilityType.CTF_LARGE_OUTPOST:
         return zoom >= 3
       default:
         return false
@@ -358,11 +362,13 @@ export class FacilityBadge {
       case FacilityType.CONSTRUCTION_OUTPOST:
       case FacilityType.CTF_SMALL_OUTPOST:
       case FacilityType.CTF_CONSTRUCTION_OUTPOST:
+      case FacilityType.UNDERWATER:
         return 9
       case FacilityType.LARGE_OUTPOST:
       case FacilityType.CTF_LARGE_OUTPOST:
         return 10
       default:
+        console.debug(`FacilityBadge::radius: Got unknown FacilityType ${type.toString()}`)
         return 0
     }
   }

--- a/libraries/FacilityBadge.ts
+++ b/libraries/FacilityBadge.ts
@@ -268,7 +268,7 @@ export class FacilityBadge {
     }
 
     this.svg
-      .use('facility-bg', FACILITY_ICON_PATH)
+      .use(FacilityBadge.SVGBackgroundDefinitionId(this.type), FACILITY_ICON_PATH)
       .addClass(this.region.id.toString())
       .fill(MAP_FACTION_COLORS[this.region.faction].toString())
 
@@ -289,7 +289,7 @@ export class FacilityBadge {
     const toReturn = SVG()
     toReturn.viewbox(0, 0, 100, 100)
     toReturn
-      .use('facility-bg', FACILITY_ICON_PATH)
+      .use(FacilityBadge.SVGBackgroundDefinitionId(this.type), FACILITY_ICON_PATH)
       .fill(MAP_FACTION_COLORS[faction].toString())
     toReturn.use(FacilityBadge.SVGDefinitionId(this.type), FACILITY_ICON_PATH)
     if (size) toReturn.width(size).height(size)
@@ -356,11 +356,39 @@ export class FacilityBadge {
     switch (type) {
       case FacilityType.SMALL_OUTPOST:
       case FacilityType.CONSTRUCTION_OUTPOST:
+      case FacilityType.CTF_SMALL_OUTPOST:
+      case FacilityType.CTF_CONSTRUCTION_OUTPOST:
         return 9
       case FacilityType.LARGE_OUTPOST:
+      case FacilityType.CTF_LARGE_OUTPOST:
         return 10
       default:
         return 0
+    }
+  }
+
+  static SVGBackgroundDefinitionId(type: FacilityType): string {
+    switch (type) {
+      case FacilityType.AMP_STATION:
+      case FacilityType.BIO_LAB:
+      case FacilityType.TECH_PLANT:
+      case FacilityType.LARGE_OUTPOST:
+      case FacilityType.SMALL_OUTPOST:
+      case FacilityType.WARPGATE:
+      case FacilityType.INTERLINK_FACILITY:
+      case FacilityType.CONSTRUCTION_OUTPOST:
+      case FacilityType.RELIC_OUTPOST:
+      case FacilityType.CONTAINMENT_SITE:
+      case FacilityType.TRIDENT:
+      case FacilityType.UNDERWATER:
+        return 'facility-bg'
+      case FacilityType.CTF_AMP_STATION:
+      case FacilityType.CTF_CONSTRUCTION_OUTPOST:
+      case FacilityType.CTF_LARGE_OUTPOST:
+      case FacilityType.CTF_SMALL_OUTPOST:
+        return 'ctf-bg'
+      default:
+        return ''
     }
   }
 
@@ -390,6 +418,14 @@ export class FacilityBadge {
         return 'trident-fg'
       case FacilityType.UNDERWATER:
         return 'seapost-fg'
+      case FacilityType.CTF_AMP_STATION:
+        return 'ctf-amp-fg'
+      case FacilityType.CTF_CONSTRUCTION_OUTPOST:
+        return 'ctf-const-outpost-fg'
+      case FacilityType.CTF_LARGE_OUTPOST:
+        return 'ctf-lg-outpost-fg'
+      case FacilityType.CTF_SMALL_OUTPOST: 
+        return 'ctf-sm-outpost-fg'
       default:
         return ''
     }

--- a/libraries/MapRegion.ts
+++ b/libraries/MapRegion.ts
@@ -82,7 +82,7 @@ export class MapRegion implements MapRegionDrawingInterface {
     })
 
     this.hexes = []
-    region.map_hexes.forEach((hex) => {
+    region.map_hexes?.forEach((hex) => {
       const r: number = -parseInt(hex.y) - 1
       const s: number = -parseInt(hex.x)
       const cubehex = CubeHex.fromAxialRS(r, s)

--- a/static/img/facility-icon.svg
+++ b/static/img/facility-icon.svg
@@ -28,7 +28,7 @@
             <polyline points="56.25,70 75,70 75,47.09 56.25,30.42  43.75,30.42 25,47.09 25,70 43.75,70"/>
         </g>
         <g id="warpgate-fg" stroke="white" stroke-width="7.5" fill="none">
-            <path d="M 30 27.5 A 34 34 0 0 0 17.66 65.5 L 50 55 L 82.34 65.5 A 34 34 0 0 0 70 27.5"/>-->
+            <path d="M 30 27.5 A 34 34 0 0 0 17.66 65.5 L 50 55 L 82.34 65.5 A 34 34 0 0 0 70 27.5"/>
             <polygon stroke="none" fill="white" points="44,65 48,15 52,15 56,65"/>
         </g>
         <g id="interlink-fg" stroke="white" fill="white" stroke-width="3.89" stroke-linejoin="miter">
@@ -78,8 +78,30 @@
             <path fill="white" stroke="none" d="M 14.644 65.355 L 30 68 L 22.5 72.5 Z"/>
             <path fill="white" stroke="none" d="M 85.355 65.355 L 70 68 L 77.5 72.5 Z"/>
         </g>
+        <g id="ctf-bg" stroke="none">
+            <rect fill="white" fill-opacity="1.0" width="10" height="100"/>
+            <rect fill="white" fill-opacity="1.0" width="100" height="85"/>
+            <rect fill-opacity="0.75" x="2.5" y="2.5" width="5" height="95"/>
+            <rect fill-opacity="0.75" x="10" y="4.25" width="85" height="76.5"/>
+        </g>
+        <g id="ctf-amp-fg" stroke="white" fill="white" transform="translate(6.125 -2.875) scale(0.925 0.925)">
+            <polygon points="55,18.75 31.25,55 50,55 45,81.25 68.75,45 50,45"/>
+        </g>
+        <g id="ctf-lg-outpost-fg" stroke="white" fill="none" stroke-width="12.5" transform="translate(6.125 -2.875) scale(0.925 0.925)">
+            <polyline stroke-width="10" points="56.25,70 75,70 75,40.41 56.25,23.75  43.75,23.75 25,40.41 25,70 43.75,70"/>
+            <line x1="75" y1="40.41" x2="87.5" y2="40.41"/>
+            <line x1="25" y1="40.41" x2="12.5" y2="40.41"/>
+        </g>
+        <g id="ctf-sm-outpost-fg" stroke="white" fill="none" stroke-width="10" transform="translate(6.125 -2.875) scale(0.925 0.925)">
+            <polyline points="56.25,70 75,70 75,47.09 56.25,30.42  43.75,30.42 25,47.09 25,70 43.75,70"/>
+        </g>
+        <g id="ctf-const-outpost-fg" stroke="white" fill="white" stroke-linejoin="miter" transform="translate(6.125 -2.875) scale(0.925 0.925)">
+            <polygon points="50,50 67.5,67.5 50,85 32.5,67.5"/>
+            <polygon points="68.75,62.5 52.5,15 52.5,45"/>
+            <polygon points="31.25,62.5 47.5,15 47.5,45"/>
+        </g>
     </defs>
-    <!--<rect x="0" y="0" width="100" height="100" fill="black"/>
-    <use href="#facility-bg" fill="red"/>
-    <use href="#const-outpost-fg"/>-->
+    <rect x="0" y="0" width="100" height="100" fill="black"/>
+    <use href="#ctf-bg" fill="red"/>
+    <use href="#ctf-amp-fg"/>
 </svg>


### PR DESCRIPTION
These changes allow us to update lattices without updating map tiles separately. Basically, all instances now have a field `latticeVersion` that can be separate from the `mapVersion`. The `latticeVersion` determines which hex and lattice layout is used, and `mapVersion` determines which tileset is used.

Additions:
* `latticeVersion` now exists on `InstanceOutfitWarsResponseInterface` and `InstanceTerritoryControlResponseInterface`
* CTF badges have been added for all types of CTF bases

Bugfixes:
* Underwater base badges now display properly
* Removed special code to handle Oshur in `_alert.vue` since Census is working better now



