### PR TITLE
ci: Declare token permissions per workflow

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     # Runs 6am on Mondays (see https://crontab.guru)
     - cron: '0 6 * * 1'
+permissions:
+  contents: read
+
 jobs:
   build-docker-images:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,6 +21,11 @@ on:
   schedule:
     - cron: '22 10 * * 1'
 
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -3,6 +3,9 @@ name: Build & Deploy Production
 on:
   push:
     branches: [master]
+permissions:
+  contents: read
+
 jobs:
   build-docker-images:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -3,6 +3,9 @@ name: Build & Deploy Staging
 on:
   push:
     branches: [staging]
+permissions:
+  contents: read
+
 jobs:
   build-docker-images:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [dev]
   pull_request:
+permissions:
+  contents: read
+
 jobs:
   eslint:
     name: ESLint

--- a/.github/workflows/ts-compile.yml
+++ b/.github/workflows/ts-compile.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [dev]
   pull_request:
+permissions:
+  contents: read
+
 jobs:
   typescript-compile:
     name: Typescript Compile


### PR DESCRIPTION
Part of standardising GitHub settings across the repos. This is the code half; the settings half is applied directly.

The repository default for `GITHUB_TOKEN` is `write`, which is more than anything here needs. Each workflow now declares what it wants, so the default can drop to read-only.

| Workflow | Permissions | Why |
|---|---|---|
| ESLint, Typescript Compile | `contents: read` | checkout only |
| Build base image, Deploy Production, Deploy Staging | `contents: read` | authenticate to Docker Hub with their own secrets |
| CodeQL | `actions: read`, `contents: read`, `security-events: write` | uploads analysis results |

CodeQL is the only exception, and worth noting: the aggregator's copy of this workflow already declares those permissions at job level, whereas this one never did and has been relying on the write default. Dropping the default without this change would have broken the upload.

## Validation

All six workflow files parse as YAML and resolve to the permissions above. ESLint, Typescript Compile and CodeQL all run on this PR, so the read-only path is exercised here — including the CodeQL upload.

Once this merges, the default token permission drops to read-only. `ESLint` and `Typescript Compile` are already required on `dev` via a branch ruleset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)